### PR TITLE
Fix session config and add JSON API endpoint

### DIFF
--- a/app/Http/Controllers/MoodleController.php
+++ b/app/Http/Controllers/MoodleController.php
@@ -23,6 +23,14 @@ class MoodleController extends Controller
         return view('moodle.cursos', compact('cursos'));
     }
 
+    /** Devolver cursos en formato JSON sin usar vistas */
+    public function cursosJson()
+    {
+        $data = $this->moodle->call('core_course_get_courses', []);
+        $cursos = $data['courses'] ?? $data;
+        return response()->json($cursos);
+    }
+
     /** Otro ejemplo: listado de cursos de un usuario */
     public function misCursos(Request $req)
     {

--- a/config/session.php
+++ b/config/session.php
@@ -18,7 +18,7 @@ return [
     |
     */
 
-    'driver' => env('SESSION_DRIVER', 'database'),
+    'driver' => env('SESSION_DRIVER', 'file'),
 
     /*
     |--------------------------------------------------------------------------

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,7 @@ Route::get('/', function () {
 
 
 Route::get('/moodle/cursos', [MoodleController::class, 'cursos']);
+Route::get('/api/moodle/cursos', [MoodleController::class, 'cursosJson']);
 Route::get('/moodle/mis-cursos', [MoodleController::class, 'misCursos']);
 Route::get('/moodle/categorias', [MoodleController::class, 'categorias']);
 Route::get('/moodle/usuarios', [MoodleController::class, 'buscarUsuarios']);

--- a/tests/Feature/MoodleRoutesTest.php
+++ b/tests/Feature/MoodleRoutesTest.php
@@ -22,6 +22,7 @@ class MoodleRoutesTest extends TestCase
     {
         foreach ([
             '/moodle/cursos',
+            '/api/moodle/cursos',
             '/moodle/mis-cursos',
             '/moodle/categorias',
             '/moodle/usuarios',


### PR DESCRIPTION
## Summary
- default sessions to use file driver to avoid MySQL requirement
- add `/api/moodle/cursos` route returning JSON
- implement `cursosJson` in controller
- adjust tests for new endpoint

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6873041ae00c8328b17322bb6a436eaf